### PR TITLE
Fix global vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- Fixed wrong initiation of `CONV_HISTORY` and other globals that led to UndefVarError. Moved several globals to `const Ref{}` pattern to ensure type stability, but it means that from now it always needs to be dereferenced with `[]` (eg, `MAIN_INDEX[]` instead of `MAIN_INDEX`).
 
-## [Unreleased]
-
-### Added
-
-### Fixed

--- a/src/AIHelpMe.jl
+++ b/src/AIHelpMe.jl
@@ -25,7 +25,7 @@ export @aihelp_str, @aihelp!_str
 include("macros.jl")
 
 ## Globals
-const CONV_HISTORY = Vector{Vector{Any}}()
+const CONV_HISTORY = Vector{Vector{PT.AbstractMessage}}()
 const CONV_HISTORY_LOCK = ReentrantLock()
 const MAX_HISTORY_LENGTH = 1
 const LAST_CONTEXT = Ref{Union{Nothing, RAG.RAGContext}}(nothing)

--- a/src/AIHelpMe.jl
+++ b/src/AIHelpMe.jl
@@ -24,14 +24,15 @@ include("generation.jl")
 export @aihelp_str, @aihelp!_str
 include("macros.jl")
 
+## Globals
+const CONV_HISTORY = Vector{Vector{Any}}()
+const CONV_HISTORY_LOCK = ReentrantLock()
+const MAX_HISTORY_LENGTH = 1
+const LAST_CONTEXT = Ref{Union{Nothing, RAG.RAGContext}}(nothing)
+const MAIN_INDEX = Ref{Union{Nothing, RAG.AbstractChunkIndex}}(nothing)
 function __init__()
-    ## Globals
-    CONV_HISTORY::Vector{Vector{<:Any}} = Vector{Vector{<:Any}}()
-    CONV_HISTORY_LOCK::ReentrantLock = ReentrantLock()
-    MAX_HISTORY_LENGTH::Int = 1
-    LAST_CONTEXT::Union{Nothing, RAG.RAGContext} = nothing
     ## Load index
-    MAIN_INDEX::Union{Nothing, RAG.AbstractChunkIndex} = load_index!()
+    MAIN_INDEX[] = load_index!()
 end
 
 end

--- a/src/generation.jl
+++ b/src/generation.jl
@@ -138,7 +138,7 @@ function aihelp(index::RAG.AbstractChunkIndex,
         filtered_candidates,
         reranked_candidates)
     lock(CONV_HISTORY_LOCK) do
-        PT.LAST_CONTEXT = rag_context
+        LAST_CONTEXT[] = rag_context
     end
 
     if return_context # for evaluation
@@ -151,6 +151,6 @@ end
 function aihelp(question::AbstractString;
         kwargs...)
     global MAIN_INDEX
-    @assert !isnothing(MAIN_INDEX) "MAIN_INDEX is not loaded. Use `load_index!` to load an index."
-    aihelp(MAIN_INDEX, question; kwargs...)
+    @assert !isnothing(MAIN_INDEX[]) "MAIN_INDEX is not loaded. Use `load_index!` to load an index."
+    aihelp(MAIN_INDEX[], question; kwargs...)
 end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -37,7 +37,7 @@ macro aihelp_str(user_question, flags...)
     model = isempty(flags) ? PT.MODEL_CHAT : only(flags)
     prompt = Meta.parse("\"$(escape_string(user_question))\"")
     quote
-        conv = aihelp($(esc(MAIN_INDEX)), $(esc(prompt));
+        conv = aihelp($(esc(MAIN_INDEX[])), $(esc(prompt));
             model = $(esc(model)),
             return_all = true)
         PT.push_conversation!($(esc(CONV_HISTORY)), conv, $(esc(MAX_HISTORY_LENGTH)))
@@ -84,7 +84,7 @@ aihelp!"Can you create it from named tuple?"gpt4t
 Ensure that the conversation history is not too long to maintain relevancy and coherence in the AI's responses. The history length is managed by `MAX_HISTORY_LENGTH`.
 """
 macro aihelp!_str(user_question, flags...)
-    global CONV_HISTORY, LAST_CONTEXT, MAIN_INDEX
+    global CONV_HISTORY, MAIN_INDEX
     model = isempty(flags) ? PT.MODEL_CHAT : only(flags)
     prompt = Meta.parse("\"$(escape_string(user_question))\"")
     quote

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -46,7 +46,7 @@ It can be useful to see the sources/references used by the AI model to generate 
 
 If you're using `aihelp()` make sure to set `return_context = true` to return the context.
 """
-last_context() = PT.LAST_CONTEXT
+last_context() = LAST_CONTEXT[]
 
 struct ContextPreview
     question::AbstractString
@@ -111,7 +111,7 @@ AIH.load_index!(index)
 function load_index!(index::RAG.AbstractChunkIndex;
         verbose::Bool = true, kwargs...)
     global MAIN_INDEX
-    MAIN_INDEX = index
+    MAIN_INDEX[] = index
     verbose && @info "Loaded index into MAIN_INDEX"
     return index
 end
@@ -127,16 +127,16 @@ function load_index!(file_path::Union{Nothing, AbstractString} = nothing;
     global MAIN_INDEX
     if !isnothing(file_path)
         @assert endswith(file_path, ".jls") "Provided file path must end with `.jls` (serialized Julia object)."
-        file_str = "from file $(file_path) "
+        file_str = " from a file $(file_path) "
     else
         artifact_path = artifact"juliaextra"
         file_path = joinpath(artifact_path, "docs-index.jls")
-        file_str = " "
+        file_str = " from an artifact "
     end
     index = deserialize(file_path)
     @assert index isa RAG.AbstractChunkIndex "Provided file path must point to a serialized RAG index (Deserialized type: $(typeof(index)))."
-    verbose && @info "Loaded index $(file_str)into MAIN_INDEX"
-    MAIN_INDEX = index
+    verbose && @info "Loaded index$(file_str)into MAIN_INDEX"
+    MAIN_INDEX[] = index
 
     return index
 end
@@ -167,7 +167,7 @@ AHM.update_index() |> AHM.load_index!
 index = AHM.update_index(index)
 ```
 """
-function update_index(index::RAG.AbstractChunkIndex = MAIN_INDEX,
+function update_index(index::RAG.AbstractChunkIndex = MAIN_INDEX[],
         modules::Vector{Module} = Base.Docs.modules;
         verbose::Integer = 1,
         separators = ["\n\n", ". ", "\n"], max_length::Int = 256,


### PR DESCRIPTION
- Fixed wrong initiation of `CONV_HISTORY` and other globals that led to UndefVarError. Moved several globals to `const Ref{}` pattern to ensure type stability, but it means that from now it always needs to be dereferenced with `[]` (eg, `MAIN_INDEX[]` instead of `MAIN_INDEX`).