### PR TITLE
fix install instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To install AIHelpMe, use the Julia package manager and the address of the reposi
 
 ```julia
 using Pkg
-Pkg.add("https://github.com/svilupp/AIHelpMe.jl")
+Pkg.add(url="https://github.com/svilupp/AIHelpMe.jl")
 ```
 
 **Prerequisites:**


### PR DESCRIPTION
url kwarg is needed otherwise installing yields this error

ERROR: `https://github.com/svilupp/AIHelpMe.jl` is not a valid package name. Perhaps you meant `https://github.com/svilupp/AIHelpMe` The argument appears to be a URL or path, perhaps you meant `Pkg.add(url="...")` or `Pkg.add(path="...")`.