### PR TITLE
Add new knowledge packs for JuliaLang, GenieFramework

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,18 +1,35 @@
+["genie__textembedding3large-0-Float32"]
+git-tree-sha1 = "453d1876a9c248dfc6a187e94ec4959199472162"
+lazy = true
+
+    [["genie__textembedding3large-0-Float32".download]]
+    sha256 = "7c50469da95c7d6387b78307ea7ac15e981c61bd4121ec9772a39f9326ef8cfc"
+    url = "https://github.com/svilupp/AIHelpMeArtifacts/raw/main/artifacts/genie__v20240818__textembedding3large-3072-Float32__v1.0.tar.gz"
+
+["genie__textembedding3large-1024-Bool"]
+git-tree-sha1 = "723a7d2e694c183de2e5dc38e0cc54c8d9f57b4c"
+lazy = true
+
+    [["genie__textembedding3large-1024-Bool".download]]
+    sha256 = "868fece03ec1f1a470f2f44e969b8452c3f7c83dcb6d03d7441d395cc753ab7a"
+    url = "https://github.com/svilupp/AIHelpMeArtifacts/raw/main/artifacts/genie__v20240818__textembedding3large-1024-Bool__v1.0.tar.gz"
+
+
 ["julia__textembedding3large-0-Float32"]
-git-tree-sha1 = "a105a2482296fa0a80ce0c76677cc9ef673be70e"
+git-tree-sha1 = "4d0b4f4627e768ab86d7b57f2968627462f5e490"
 lazy = true
 
     [["julia__textembedding3large-0-Float32".download]]
-    sha256 = "ff4e91908fb54b7919aad9d6a2ac5045124d43eb864fe9f96a7a68d304d4e0a2"
-    url = "https://github.com/svilupp/AIHelpMeArtifacts/raw/main/artifacts/julia__v1.10.2__textembedding3large-0-Float32__v1.0.tar.gz"
+    sha256 = "ff76b9b20b1307b5299977710f0d104f84cd4314cb30f5971ebe7d644742fc95"
+    url = "https://github.com/svilupp/AIHelpMeArtifacts/raw/main/artifacts/julialang__v20240819__textembedding3large-3072-Float32__v1.0.tar.gz"
 
 ["julia__textembedding3large-1024-Bool"]
-git-tree-sha1 = "7eef82f15c72712b4f5fff2449ebf3ed64b56b14"
+git-tree-sha1 = "365d9e59be009b7050db7112be0dd89b7be332bc"
 lazy = true
 
     [["julia__textembedding3large-1024-Bool".download]]
-    sha256 = "27186886d19ea4c3f1710b4bc70e8e809d906069d5de8c992c948d97d0f454da"
-    url = "https://github.com/svilupp/AIHelpMeArtifacts/raw/main/artifacts/julia__v1.10.2__textembedding3large-1024-Bool__v1.0.tar.gz"
+    sha256 = "8a88839594479ab12bd81a9a47e3bc4e2bd8aec02ad88db1dc3369b2cdb45e61"
+    url = "https://github.com/svilupp/AIHelpMeArtifacts/raw/main/artifacts/julialang__v20240819__textembedding3large-1024-Bool__v1.0.tar.gz"
 
 ["juliadata__textembedding3large-0-Float32"]
 git-tree-sha1 = "5ea13051e16f01627a4c81fd74e664a396785934"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [0.4.0]
+
+### Added
+- Added the knowledge pack for GenieFramework org. (alias `:genie`).
+
+### Updated
+- Updated the knowledge pack for core Julia docs (alias `:julia`).
+
+Both were made possible by [Splendidbug](https://github.com/splendidbug)!
+
 ## [0.3.0]
 ### Added (thanks to [Splendidbug](https://github.com/splendidbug)!)
 - New knowledge packs created by Splendidbug using `DocsScraper.jl` (to be registered soon, created as part of Google Summer of Code).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Both were made possible by [Splendidbug](https://github.com/splendidbug)!
 
+### Fixed
+- Fixed a bug in `aihelp()` where `rerank=false` and `search=false` would not block these steps if they were previously enabled.
+
 ## [0.3.0]
 ### Added (thanks to [Splendidbug](https://github.com/splendidbug)!)
 - New knowledge packs created by Splendidbug using `DocsScraper.jl` (to be registered soon, created as part of Google Summer of Code).

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AIHelpMe"
 uuid = "01402e1f-dc83-4213-a98b-42887d758baa"
 authors = ["J S <49557684+svilupp@users.noreply.github.com> and contributors"]
-version = "0.3.0"
+version = "0.4.0"
 
 [deps]
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"

--- a/src/generation.jl
+++ b/src/generation.jl
@@ -89,11 +89,15 @@ function aihelp(cfg_orig::RT.AbstractRAGConfig, index::RT.AbstractChunkIndex,
         ## Use Cohere reranking model
         @assert !isempty(PT.COHERE_API_KEY) "COHERE_API_KEY is not set! Cannot use the reranker functionality."
         cfg.retriever.reranker = RT.CohereReranker()
+    elseif !isnothing(rerank) && !rerank
+        cfg.retriever.reranker = RT.NoReranker()
     end
     if !isnothing(search) && search
         ##set TavilySearchRefiner - Requires TAVILY_API_KEY
         @assert !isempty(PT.TAVILY_API_KEY) "TAVILY_API_KEY is not set! Cannot use the web search refinement functionality."
         cfg.generator.refiner = RT.TavilySearchRefiner()
+    elseif !isnothing(search) && !search
+        cfg.generator.refiner = RT.NoRefiner()
     end
 
     ## Run the RAG pipeline

--- a/src/loading.jl
+++ b/src/loading.jl
@@ -61,7 +61,7 @@ load_index!(:julia)
 
 Or multiple packs
 ```julia
-load_index!([:julia, :juliadata, :makie, :tidier, :plots, :sciml])
+load_index!([:julia, :juliadata, :makie, :tidier, :plots, :sciml, :genie])
 ```
 But we recommend loading ONLY the packs you expect to need - unnecessary packs introduce noise.
 """

--- a/src/user_preferences.jl
+++ b/src/user_preferences.jl
@@ -14,6 +14,7 @@ global MAIN_INDEX::Union{Nothing, RT.AbstractChunkIndex} = nothing
 Currently available packs are:
 - `:julia` - Julia documentation, standard library docstrings and a few extras (for Julia v1.10)
 - `:juliadata` - JuliaData.jl organization documentation, eg, DataFrames.jl and similar packages
+- `:genie` - GenieFramework organization documentation, eg, Genie.jl, Stipple.jl, StippleUI.jl, etc
 - `:plots` - Plots.jl organization documentation, eg, Plots.jl, StatsPlots.jl, etc
 - `:makie` - Makie.jl organization documentation
 - `:tidier` - Tidier.jl organization documentation
@@ -21,7 +22,7 @@ Currently available packs are:
 
 These packs have been sourced and packaged with DocsScraper.jl.
 """
-const ALLOWED_PACKS = [:julia, :juliadata, :tidier, :sciml, :plots, :makie]
+const ALLOWED_PACKS = [:julia, :juliadata, :tidier, :sciml, :plots, :makie, :genie]
 
 """
     LOADED_PACKS


### PR DESCRIPTION
### Added
- Added the knowledge pack for GenieFramework org. (alias `:genie`).

### Updated
- Updated the knowledge pack for core Julia docs (alias `:julia`).

Both were made possible by [Splendidbug](https://github.com/splendidbug)!
